### PR TITLE
fix for when the top bar expands when tethering on iOS

### DIFF
--- a/ios/RCCOverlayView.h
+++ b/ios/RCCOverlayView.h
@@ -9,6 +9,5 @@
 @property (nonatomic, strong) UITabBar *tabBar;
 
 - (instancetype)initWithProps:(NSDictionary *)overlayProps bridge:(RCTBridge *)bridge;
-- (void)setTabBarForBottomConstraint:(UITabBar *)tabBar;
 
 @end

--- a/ios/RCCOverlayView.m
+++ b/ios/RCCOverlayView.m
@@ -23,12 +23,8 @@
     return self;
 }
 
-- (void)setTabBarForBottomConstraint:(UITabBar *)tabBar {
-    self.tabBar = tabBar; // Will be used later in setupViewConstraints:
-}
-
--(void)didMoveToSuperview {
-    [self setupViewConstraints:self.overlayProps bottomView:self.tabBar];
+- (void)didMoveToSuperview {
+    [self setupViewConstraints:self.overlayProps bottomView:nil];
 }
 
 - (void)setupViewConstraints:(NSDictionary *)overlayProps bottomView:(UIView *)bottomView {
@@ -66,7 +62,7 @@
         }
         
         if (bottomView) {
-            // Sticks the bottom of this overlay view to the top of the tab bar
+            // Sticks the bottom of this overlay view to the top of this view
             NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:bottomView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
             constraint.active = YES;
         } else if (style[@"marginBottom"]) {

--- a/ios/RCCViewController.m
+++ b/ios/RCCViewController.m
@@ -73,7 +73,6 @@ const NSInteger TRANSPARENT_NAVBAR_TAG = 78264803;
         
         if (props[@"overlay"]) {
             RCCOverlayView *overlayView = [[RCCOverlayView alloc] initWithProps:props[@"overlay"] bridge:bridge];
-            [overlayView setTabBarForBottomConstraint:((UITabBarController *) controller).tabBar];
             [overlayView setHidden:YES];
 
             [controller.view insertSubview:overlayView belowSubview:((UITabBarController *) controller).tabBar];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation",
-  "version": "1.1.407",
+  "version": "1.1.408",
   "description": "React Native Navigation - truly native navigation for iOS and Android",
   "license": "MIT",
   "nativePackage": true,


### PR DESCRIPTION
When tethering or in a call the top bar on iOS expands. For some reason the overlay was no longer sticking to the navigation bar. This fixes that issue.